### PR TITLE
Updating to .Net Core 1.0 and adding net40 as a target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ ipch/
 *.aps
 *.ncb
 *.opendb
+*.db
 *.opensdf
 *.sdf
 *.cachefile

--- a/src/Sandbox/project.json
+++ b/src/Sandbox/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.2.1-*",
+  "version": "1.2.2-*",
   "description": "Sandbox Console Application",
   "authors": [ "Paul" ],
   "buildOptions": {
@@ -7,11 +7,6 @@
   },
 
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "type": "platform",
-      "version": "1.0.0-rc2-3002702"
-    },
-    "System.Runtime": "4.1.0-rc2-24027",
     "VroomJs": {
       "target": "project"
     }
@@ -19,7 +14,15 @@
 
   "frameworks": {
     "netcoreapp1.0": {
-      "imports": "dnxcore50"
-    }
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    },
+    "net45": {},
+    "net40": {} 
   }
 }

--- a/src/VroomJs/AssemblyLoader.cs
+++ b/src/VroomJs/AssemblyLoader.cs
@@ -29,7 +29,12 @@ namespace VroomJs
 
             var dllPath = Path.Combine(dirName, dllName + ".dll");
 
+#if DOTNETCORE
             using (Stream stm = typeof(JsEngine).GetTypeInfo().Assembly.GetManifestResourceStream("VroomJs." + dllName + "-" + architecture + ".dll"))
+#else
+            using (Stream stm = typeof(JsEngine).Assembly.GetManifestResourceStream("VroomJs." + dllName + "-" + architecture + ".dll"))
+#endif
+
             {
                 try
                 {
@@ -64,10 +69,10 @@ namespace VroomJs
         {
             if (_isLoaded) return;
 
-            #if DOTNETCORE
+#if DOTNETCORE
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 throw new Exception("EnsureLoaded: May only be used on Windows platforms. For other platforms, you must manually build VroomJsNative.dll");
-            #endif
+#endif
 
             lock (_lock)
             {

--- a/src/VroomJs/JsConvert.cs
+++ b/src/VroomJs/JsConvert.cs
@@ -128,10 +128,11 @@ namespace VroomJs
 
             Type type = obj.GetType();
 
+#if !DOTNET40
             // Check for nullable types (we will cast the value out of the box later).
-
             if (type.IsConstructedGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
                 type = type.GetGenericArguments()[0];
+#endif
 
             if (type == typeof(Boolean))
                 return new JsValue { Type = JsValueType.Boolean, I32 = (bool)obj ? 1 : 0 };

--- a/src/VroomJs/JsFunction.cs
+++ b/src/VroomJs/JsFunction.cs
@@ -26,11 +26,18 @@ namespace VroomJs {
 		}
 
 		public object MakeDelegate(Type type, object[] args) {
-			if (type.GetTypeInfo().BaseType != typeof(MulticastDelegate)) {
+#if DOTNETCORE
+            if (type.GetTypeInfo().BaseType != typeof(MulticastDelegate)) {
 				throw new Exception("Not a delegate.");
 			}
+#else
+            if (type.BaseType != typeof(MulticastDelegate))
+            {
+                throw new Exception("Not a delegate.");
+            }
+#endif
 
-			MethodInfo invoke = type.GetMethod("Invoke");
+            MethodInfo invoke = type.GetMethod("Invoke");
 			if (invoke == null) {
 				throw new Exception("Not a delegate.");
 			}
@@ -60,7 +67,7 @@ namespace VroomJs {
 			return Expression.Lambda(type, callExpression, parameters).Compile();
 		}
 
-		#region IDisposable implementation
+#region IDisposable implementation
 
         bool _disposed;
 
@@ -86,6 +93,6 @@ namespace VroomJs {
 				Dispose(false);
 		}
 
-		#endregion
+#endregion
 	}
 }

--- a/src/VroomJs/project.json
+++ b/src/VroomJs/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.2.1-*",
+  "version": "1.2.2-*",
   "description": "An embedded V8 engine for .NET CLR and .NET Core.",
   "packOptions": {
     "summary": "An embedded V8 engine for .NET CLR and .NET Core.",
@@ -18,28 +18,26 @@
     ]
   },
   "frameworks": {
-    "netstandard1.3": {
+    "netstandard1.6": {
       "imports": [
+        "dnxcore50",
         "portable-net451+win8"
       ],
       "dependencies": {
-        "System.Threading": "4.0.11-rc2-*",
-        "System.Collections": "4.0.11-rc2-*",
-        "System.IO.FileSystem": "4.0.1-rc2-*",
-        "System.Reflection": "4.1.0-rc2-*",
-        "System.Runtime.Extensions": "4.1.0-rc2-*",
-        "System.Dynamic.Runtime": "4.0.11-rc2-*",
-        "System.Reflection.TypeExtensions": "4.1.0-rc2-*",
-        "System.Runtime.InteropServices": "4.1.0-rc2-*",
-        "System.Linq": "4.1.0-rc2-*",
-        "System.Linq.Expressions": "4.0.11-rc2-*",
-        "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-*",
-        "System.Runtime.Handles": "4.0.1-rc2-24027"
+        "NETStandard.Library": "1.6.0",
+        "System.Dynamic.Runtime": "4.0.11",
+        "System.Reflection.TypeExtensions": "4.1.0"
       },
       "buildOptions": { "define": [ "DOTNETCORE" ] }
     },
+    "net40": {
+      "buildOptions": { "define": [ "DOTNETCLR", "DOTNET40" ] }
+    },
     "net45": {
-      "buildOptions": { "define": [ "DOTNETCLR" ] }
+      "buildOptions": { "define": [ "DOTNETCLR" ] },
+      "dependencies": {
+        "System.Dynamic.Runtime": "4.0.0"
+      }
     }
   }
 }


### PR DESCRIPTION
I've updated the framework definitions to the latest as far as a "portable" library is concerned.  It still is Windows only because of the embedded dlls, but should met the requirements for how the project.json is structured.  I'm not quite sure the process for embedding different DLLs for different OS but this is a stepping stone to get things updated.
