### PR TITLE
.NET Standard 1.6 -> 1.3

### DIFF
--- a/src/VroomJs/project.json
+++ b/src/VroomJs/project.json
@@ -19,7 +19,7 @@
     "keyFile": "key.snk"
   },
   "frameworks": {
-    "netstandard1.6": {
+    "netstandard1.3": {
       "imports": [
         "dnxcore50",
         "portable-net451+win8"


### PR DESCRIPTION
It would be nice to downgrade .NET Standard version from 1.6 to 1.3. In general, class libraries which target a lower [.NET Platform Standard](https://github.com/dotnet/corefx/blob/master/Documentation/architecture/net-platform-standard.md) version, can be loaded by the largest number of existing platforms.
