### PR TITLE
Delete jsscript.h

### DIFF
--- a/native/libVroomJs/jsscript.h
+++ b/native/libVroomJs/jsscript.h
@@ -1,8 +1,0 @@
-#pragma once
-class jsscript
-{
-public:
-	jsscript(void);
-	~jsscript(void);
-};
-


### PR DESCRIPTION
Causes a build error if included when building the library. It's best to avoid someone else's confusion by just deleting this file, especially since this file is not used.